### PR TITLE
Enabled mobile support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
     "root": true,
     "parser": "@typescript-eslint/parser",
-    "env": { "node": true },
     "plugins": [
       "@typescript-eslint"
     ],

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -27,7 +27,6 @@ const context = await esbuild.context({
 	],
 	external: [
 		"obsidian",
-		"electron",
 		"@codemirror/autocomplete",
 		"@codemirror/collab",
 		"@codemirror/commands",

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -27,6 +27,7 @@ const context = await esbuild.context({
 	],
 	external: [
 		"obsidian",
+		"electron",
 		"@codemirror/autocomplete",
 		"@codemirror/collab",
 		"@codemirror/commands",

--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,5 @@
 	"author": "Brandon Boswell",
 	"authorUrl": "https://brandonkboswell.com/",
 	"fundingUrl": "https://link.brandonkboswell.com/coffee",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "last-time",
+  "name": "reflection",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "last-time",
+      "name": "reflection",
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,6 +33,7 @@ export default defineConfig(() => {
                     assetFileNames: 'styles.css',
                 },
                 external: ['obsidian',
+                    'electron',
                     "codemirror",
                     "@codemirror/autocomplete",
                     "@codemirror/closebrackets",

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,7 +33,6 @@ export default defineConfig(() => {
                     assetFileNames: 'styles.css',
                 },
                 external: ['obsidian',
-                    'electron',
                     "codemirror",
                     "@codemirror/autocomplete",
                     "@codemirror/closebrackets",


### PR DESCRIPTION
As mentioned in #2 this Plugin can't be activated on mobile because `isDesktopOnly` is set.
Because we don't use node or electron APIs the option can be disabled.
I tested this in Obsidian desktop, with `this.app.emulateMobile` and on mobile and it worked as expected.